### PR TITLE
docs: document test mode workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ and ships with an operational dashboard, alerting, and Dockerized deployment for
   fallbacks covering ~30k SKUs per marketplace.
 - **Extensible Architecture** – Modular services with clear boundaries, async database access, and
   easily swappable pricing strategies or marketplace coverage.
+- **Test & Simulation Mode** – Sandbox-friendly flows for loading sample catalog data, rehearsing
+  repricing profiles, and reviewing run telemetry without touching production listings.
 
 ## Architecture Overview
 
@@ -95,6 +97,114 @@ ABCD123,ASIN0001,19.99,18.50
 
 Feeds older than the configurable threshold (default 90 minutes) trigger alerts and block repricing
 runs until refreshed.
+
+## Test Mode & Simulation
+
+Use the local/sandbox "test mode" to validate pricing logic end-to-end without publishing real
+updates to Amazon. The workflow consists of populating sample data, selecting a repricing profile,
+triggering a simulation, and reviewing the resulting telemetry.
+
+### Upload Sample Data
+
+1. **Seed sample SKUs** – The startup hook inserts marketplace rows, so you can associate SKUs by
+   code instead of hard-coding IDs:
+
+   ```sql
+   -- Populate a defensive and an aggressive SKU in the Germany marketplace
+   INSERT INTO skus (sku, asin, marketplace_id, min_price, min_business_price, hold_buy_box)
+   SELECT 'SKU-DE-TEST-1', 'ASINDE001', id, 19.99, 18.50, TRUE FROM marketplaces WHERE code = 'DE';
+   INSERT INTO skus (sku, asin, marketplace_id, min_price, min_business_price, hold_buy_box)
+   SELECT 'SKU-DE-TEST-2', 'ASINDE002', id, 17.49, 16.00, FALSE FROM marketplaces WHERE code = 'DE';
+   ```
+
+2. **Drop floor prices** – Place a CSV per marketplace under `ftp_feeds/` using the loader naming
+   convention. For example `ftp_feeds/de_floor_prices.csv`:
+
+   ```csv
+   SKU,ASIN,MIN_PRICE,MIN_BUSINESS_PRICE
+   SKU-DE-TEST-1,ASINDE001,18.00,17.00
+   SKU-DE-TEST-2,ASINDE002,15.50,14.75
+   ```
+
+3. **(Optional) Upload via the UI** – The dashboard ships with a "Bulk price file" form that
+   forwards CSV/XML payloads through `/api/actions/bulk-upload`. Point it at the Amazon sandbox (see
+   below) to rehearse full feed submission.
+
+### Enable Test Mode
+
+Run the stack with sandbox credentials so the SP-API client talks to Amazon's non-production
+endpoint and records responses locally:
+
+```bash
+export SP_API_ENDPOINT="https://sandbox.sellingpartnerapi-eu.amazon.com"
+export SP_API_CLIENT_ID="<sandbox-client-id>"
+export SP_API_CLIENT_SECRET="<sandbox-client-secret>"
+export SP_API_REFRESH_TOKEN="<sandbox-refresh-token>"
+uvicorn sdtrepricer.app:app --reload
+```
+
+Leaving the production endpoint untouched while using sandbox credentials prevents live offers from
+changing and keeps the emitted `price_events` tagged with the `repricer` reason for audit review.
+
+### Adjust Dynamic Price-Increase Guardrails
+
+The dashboard exposes a configuration form powered by `/api/settings`. Update test-mode guardrails
+directly from the UI or via API calls to rehearse aggressive vs. conservative strategies:
+
+```bash
+curl -X POST http://localhost:8000/api/settings \
+  -H 'Content-Type: application/json' \
+  -d '{
+        "max_price_change_percent": 15,
+        "step_up_percentage": 3.5,
+        "step_up_interval_hours": 4
+      }'
+```
+
+Behind the scenes these values land in the `system_settings` table and are pulled into the
+`PricingStrategy` constructor so daily guardrails and Buy Box step-ups respond instantly.
+
+### Define and Apply Repricing Profiles
+
+Treat a "repricing profile" as a named bundle of guardrails. Persist reusable profiles alongside the
+live configuration so you can switch strategies between simulations:
+
+```sql
+INSERT INTO system_settings (key, value)
+VALUES
+  ('profile:defensive', '{"max_price_change_percent": 10, "step_up_percentage": 1.5, "step_up_interval_hours": 8}'),
+  ('profile:aggressive', '{"max_price_change_percent": 25, "step_up_percentage": 5, "step_up_interval_hours": 2}')
+ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value;
+```
+
+When you're ready to test a profile, fetch its JSON payload and post it to `/api/settings` to make it
+the active configuration. The scheduler will pick up the new limits on the next tick without
+restarting the service.
+
+### Run a Simulation and Review Outcomes
+
+1. Trigger a run in test mode using the dashboard "Trigger Repricing" form or curl:
+
+   ```bash
+   curl -X POST http://localhost:8000/api/actions/manual-reprice \
+     -H 'Content-Type: application/json' \
+     -d '{"marketplace_code": "DE", "skus": []}'
+   ```
+
+2. Open the dashboard to monitor progress. The **System Health** panel exposes `scheduler.stats`,
+   while **Alerts** surface stale feeds or missing floors detected during the run.
+
+3. Inspect the relational telemetry:
+
+   ```sql
+   SELECT * FROM repricing_runs ORDER BY started_at DESC LIMIT 5;
+   SELECT sku, new_price, context ->> 'target_competitor'
+   FROM price_events
+   ORDER BY created_at DESC LIMIT 5;
+   ```
+
+Combine the dashboard snapshot with the SQL queries to interpret simulation results—processed SKU
+counts, price deltas, and competitor context—before promoting a profile to production.
 
 ## Extensibility Roadmap
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -37,14 +37,17 @@ graph TD
 - **Scheduler** – Consumes SP-API notifications, user-triggered actions, and timed fallbacks. It
   batches SKU work while respecting configurable concurrency limits.
 - **Repricing Engine** – Applies pricing strategy rules, enforces floor prices, and logs each change
-  to `price_events` for auditability.
+  to `price_events` for auditability. Dynamic guardrails (`max_price_change_percent`, Buy Box step-up
+  percentage/interval) are injected here so pricing behavior can be tuned without redeploying.
 - **FTP Loader** – Validates hourly floor files per marketplace and surfaces alerts when feeds are
   missing or stale beyond the configured threshold.
 - **Alert Service** – Normalizes health issues (FTP, API failures, Buy Box drops) and stores them for
   dashboard visibility and future notification delivery (email/Slack).
 - **FastAPI Application** – Hosts REST endpoints and the internal dashboard, exposing metrics,
-  settings, manual controls, and alert feeds.
+  settings, manual controls, and alert feeds. The dashboard also exposes forms for sandbox test mode,
+  repricing profile swaps, and bulk feed rehearsal.
 - **PostgreSQL** – Normalized schema capturing marketplaces, SKUs, repricing telemetry, and alerts.
+  The `system_settings` table stores both live guardrails and reusable repricing profiles.
 
 ## Database Schema Overview
 
@@ -66,3 +69,26 @@ graph TD
    pushes updates back to Amazon, and records results in the database.
 4. The dashboard polls REST endpoints for metrics, health status, alerts, and configuration values,
    enabling operators to monitor and intervene in real time.
+
+## Test Mode & Simulation Support
+
+- **Sandbox connectivity** – Switching `Settings.sp_api_endpoint` to the Amazon sandbox keeps price
+  updates and feed uploads isolated from production while exercising the same orchestration path.
+- **Sample data ingestion** – Operators drop CSVs into `ftp_feeds/<marketplace>_floor_prices.csv` or
+  submit them through the dashboard bulk upload form to seed simulations.
+- **Scheduler telemetry** – `RepricingScheduler.stats` captures processed/updated/error counts per
+  marketplace, surfaced via the dashboard "System Health" pane during a test run.
+- **Historical review** – `repricing_runs` and `price_events` accumulate the outcomes of each
+  simulation, including competitor context stored on the price-event `context` JSON column.
+
+## Repricing Profiles & Dynamic Guardrails
+
+- **Profile storage** – Named profiles live alongside other settings in `system_settings` as JSON
+  payloads (`profile:<name>`). The active profile is mirrored into `max_price_change_percent`,
+  `step_up_percentage`, and `step_up_interval_hours` rows consumed by the API.
+- **Runtime application** – The dashboard's settings form (backed by `/api/settings`) posts guardrail
+  changes that are immediately injected into `PricingStrategy` instances through dependency
+  resolution.
+- **Behavioral impact** – Profiles adjust how the repricer steps prices up while holding the Buy Box,
+  how aggressively it chases competitors, and how much daily variance is allowed, enabling quick
+  shifts between conservative and aggressive strategies without code changes.


### PR DESCRIPTION
## Summary
- expand the README with guidance for loading sample data, enabling sandbox test mode, and adjusting dynamic price guardrails
- document how to define reusable repricing profiles and interpret simulation telemetry from the dashboard and database
- update the architecture guide with additional context on test mode flows and the system_settings-backed guardrail management

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68c96a9939f483258af40faaec66ef80