### PR TITLE
Support configurable step-up profiles

### DIFF
--- a/sdtrepricer/app/core/config.py
+++ b/sdtrepricer/app/core/config.py
@@ -41,6 +41,9 @@ class Settings(BaseSettings):
     repricing_batch_size: int = 40
     repricing_concurrency: int = 8
     max_price_change_percent: float = 20.0
+    step_up_type: Literal["percentage", "absolute"] = "percentage"
+    step_up_value: float = 2.0
+    step_up_interval_hours: float = 6.0
     sp_api_endpoint: str = "https://sellingpartnerapi-eu.amazon.com"
 
 

--- a/sdtrepricer/app/schemas.py
+++ b/sdtrepricer/app/schemas.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from decimal import Decimal
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
@@ -42,8 +42,9 @@ class RepricerSettings(BaseModel):
     """Repricer configurable options."""
 
     max_price_change_percent: float
-    step_up_percentage: float
-    step_up_interval_hours: int
+    step_up_type: Literal["percentage", "absolute"]
+    step_up_value: float
+    step_up_interval_hours: float
 
 
 class ManualRepriceRequest(BaseModel):

--- a/sdtrepricer/app/services/alerts.py
+++ b/sdtrepricer/app/services/alerts.py
@@ -20,7 +20,7 @@ async def create_alert(
     alert = Alert(
         message=message,
         severity=severity.value,
-        metadata=metadata,
+        metadata_payload=metadata,
         created_at=datetime.utcnow(),
     )
     session.add(alert)

--- a/sdtrepricer/app/static/js/dashboard.js
+++ b/sdtrepricer/app/static/js/dashboard.js
@@ -55,7 +55,8 @@ function renderAlerts(alerts) {
 function populateSettings(settings) {
   const form = document.getElementById('settings-form');
   form.max_price_change_percent.value = settings.max_price_change_percent;
-  form.step_up_percentage.value = settings.step_up_percentage;
+  form.step_up_type.value = settings.step_up_type;
+  form.step_up_value.value = settings.step_up_value;
   form.step_up_interval_hours.value = settings.step_up_interval_hours;
 }
 
@@ -76,8 +77,9 @@ async function handleSettings(event) {
   const form = event.target;
   const payload = {
     max_price_change_percent: parseFloat(form.max_price_change_percent.value),
-    step_up_percentage: parseFloat(form.step_up_percentage.value),
-    step_up_interval_hours: parseInt(form.step_up_interval_hours.value, 10),
+    step_up_type: form.step_up_type.value,
+    step_up_value: parseFloat(form.step_up_value.value),
+    step_up_interval_hours: parseFloat(form.step_up_interval_hours.value),
   };
   try {
     await fetchJSON(`${API_BASE}/settings`, {

--- a/sdtrepricer/app/templates/dashboard.html
+++ b/sdtrepricer/app/templates/dashboard.html
@@ -41,12 +41,19 @@
             <input type="number" step="0.1" name="max_price_change_percent" required />
           </label>
           <label>
-            Step-up percentage when holding Buy Box (%)
-            <input type="number" step="0.1" name="step_up_percentage" required />
+            Step-up type
+            <select name="step_up_type" required>
+              <option value="percentage">Percentage</option>
+              <option value="absolute">Absolute</option>
+            </select>
+          </label>
+          <label>
+            Step-up value
+            <input type="number" step="0.01" name="step_up_value" required />
           </label>
           <label>
             Step-up interval (hours)
-            <input type="number" name="step_up_interval_hours" required />
+            <input type="number" step="0.1" name="step_up_interval_hours" required />
           </label>
           <button type="submit">Update Settings</button>
         </form>

--- a/sdtrepricer/tests/test_dashboard_api.py
+++ b/sdtrepricer/tests/test_dashboard_api.py
@@ -29,6 +29,9 @@ async def test_dashboard_endpoint(db_session):
             sku,
             Alert(message="Test alert", severity="WARNING"),
             SystemSetting(key="max_price_change_percent", value="15"),
+            SystemSetting(key="step_up_type", value="absolute"),
+            SystemSetting(key="step_up_value", value="1.5"),
+            SystemSetting(key="step_up_interval_hours", value="4"),
         ]
     )
     await db_session.commit()
@@ -54,3 +57,6 @@ async def test_dashboard_endpoint(db_session):
     payload = response.json()
     assert payload["metrics"][0]["buy_box_skus"] == 1
     assert payload["alerts"][0]["message"] == "Test alert"
+    assert payload["settings"]["step_up_type"] == "absolute"
+    assert payload["settings"]["step_up_value"] == 1.5
+    assert payload["settings"]["step_up_interval_hours"] == 4.0

--- a/sdtrepricer/tests/test_strategy.py
+++ b/sdtrepricer/tests/test_strategy.py
@@ -33,16 +33,58 @@ def test_competitor_undercut():
     assert result.new_price >= Decimal("10.00")
 
 
-def test_buy_box_step_up():
+def test_buy_box_percentage_step_up():
     sku = build_sku(
         hold_buy_box=True,
         last_updated_price=Decimal("20.00"),
         last_price_update=datetime.utcnow() - timedelta(hours=8),
     )
     floor = FloorPriceRecord("SKU123", "ASIN123", 10.0, 12.0)
-    strategy = PricingStrategy(step_up_percentage=5, step_up_interval_hours=6)
+    strategy = PricingStrategy(
+        step_up_type="percentage",
+        step_up_value=5,
+        step_up_interval_hours=6,
+        max_daily_change_percent=100,
+    )
     result = strategy.determine_price(sku, [], floor)
     assert result.new_price >= Decimal("21.00")
+    assert result.context["step_up"]["type"] == "percentage"
+
+
+def test_buy_box_absolute_step_up():
+    sku = build_sku(
+        hold_buy_box=True,
+        last_updated_price=Decimal("20.00"),
+        last_price_update=datetime.utcnow() - timedelta(hours=8),
+    )
+    floor = FloorPriceRecord("SKU123", "ASIN123", 10.0, 12.0)
+    strategy = PricingStrategy(
+        step_up_type="absolute",
+        step_up_value=Decimal("2.50"),
+        step_up_interval_hours=4,
+        max_daily_change_percent=100,
+    )
+    result = strategy.determine_price(sku, [], floor)
+    assert result.new_price == Decimal("22.50")
+    assert result.context["step_up"]["type"] == "absolute"
+
+
+def test_step_up_interval_enforced():
+    sku = build_sku(
+        hold_buy_box=True,
+        last_updated_price=Decimal("20.00"),
+        last_price_update=datetime.utcnow() - timedelta(hours=1),
+    )
+    floor = FloorPriceRecord("SKU123", "ASIN123", 10.0, 12.0)
+    strategy = PricingStrategy(
+        step_up_type="absolute",
+        step_up_value=Decimal("5.00"),
+        step_up_interval_hours=6,
+        max_daily_change_percent=100,
+    )
+    result = strategy.determine_price(sku, [], floor)
+    assert result.new_price == Decimal("20.00")
+    assert result.context["step_up_candidate"] is None
 
 
 def test_daily_threshold_is_enforced():


### PR DESCRIPTION
## Summary
- extend PricingStrategy to handle percentage or fixed step-up values with configurable intervals and profile overrides
- add RepricingProfile model plus API/UI settings changes to manage default step-up type, value, and cadence
- cover the new behaviour with strategy and repricer tests alongside dashboard settings updates

## Testing
- PYTHONPATH=. pytest *(fails: ModuleNotFoundError for aiosqlite in test fixtures)*

------
https://chatgpt.com/codex/tasks/task_e_68c958c4c0388325adaeb0532de61cfe