### PR TITLE
Add repricing profiles with scheduling support

### DIFF
--- a/sdtrepricer/app/api/__init__.py
+++ b/sdtrepricer/app/api/__init__.py
@@ -2,9 +2,10 @@
 
 from fastapi import APIRouter
 
-from . import actions, dashboard, settings
+from . import actions, dashboard, profiles, settings
 
 api_router = APIRouter()
 api_router.include_router(dashboard.router, tags=["dashboard"], prefix="/metrics")
 api_router.include_router(settings.router, tags=["settings"])
 api_router.include_router(actions.router, tags=["actions"], prefix="/actions")
+api_router.include_router(profiles.router)

--- a/sdtrepricer/app/api/actions.py
+++ b/sdtrepricer/app/api/actions.py
@@ -24,7 +24,9 @@ async def manual_reprice(
     scheduler = getattr(request.app.state, "scheduler", None)
     if not scheduler:
         raise HTTPException(status_code=503, detail="Scheduler not running")
-    await scheduler.trigger_marketplace(payload.marketplace_code, reason="manual")
+    await scheduler.trigger_marketplace(
+        payload.marketplace_code, reason="manual", profile_id=payload.profile_id
+    )
     return {"status": "scheduled"}
 
 

--- a/sdtrepricer/app/api/dashboard.py
+++ b/sdtrepricer/app/api/dashboard.py
@@ -8,6 +8,7 @@ from fastapi import APIRouter, Depends, Request
 from sqlalchemy import case, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from ..core.config import settings
 from ..dependencies import get_db
 from ..models import Alert, Marketplace, Sku, SystemSetting
 from ..schemas import AlertPayload, DashboardPayload, MarketplaceMetrics, RepricerSettings, SystemHealth
@@ -59,7 +60,7 @@ async def get_dashboard(
             severity=alert.severity,
             created_at=alert.created_at,
             acknowledged=alert.acknowledged,
-            metadata=alert.metadata,
+            metadata=alert.metadata_payload,
         )
         for alert in alerts_rows
     ]
@@ -83,7 +84,7 @@ async def get_dashboard(
     if scheduler:
         health_details = {
             "last_runs": {k: v.isoformat() for k, v in scheduler.last_runs.items()},
-            "stats": scheduler.stats,
+            "stats": {k: v for k, v in scheduler.stats.items()},
         }
     health = SystemHealth(status="ok", timestamp=datetime.utcnow(), details=health_details)
     return DashboardPayload(metrics=metrics, health=health, alerts=alerts, settings=repricer_settings)

--- a/sdtrepricer/app/api/profiles.py
+++ b/sdtrepricer/app/api/profiles.py
@@ -1,0 +1,198 @@
+"""API endpoints for repricing profile management."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import func, select, tuple_, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..dependencies import get_db
+from ..migrations.profile_defaults import DEFAULT_PROFILE_NAME
+from ..models import Marketplace, RepricingProfile, Sku
+from ..schemas import (
+    ProfileAssignmentRequest,
+    ProfileSkuSummary,
+    RepricingProfileCreate,
+    RepricingProfileDetail,
+    RepricingProfileOut,
+    RepricingProfileUpdate,
+)
+
+router = APIRouter(prefix="/profiles", tags=["profiles"])
+
+
+def _to_schema(profile: RepricingProfile, sku_count: int) -> RepricingProfileOut:
+    return RepricingProfileOut(
+        id=profile.id,
+        name=profile.name,
+        frequency_minutes=profile.frequency_minutes,
+        aggressiveness=profile.aggressiveness,
+        price_change_limit_percent=float(profile.price_change_limit_percent),
+        margin_policy=profile.margin_policy,
+        step_up_percentage=float(profile.step_up_percentage),
+        step_up_interval_hours=profile.step_up_interval_hours,
+        sku_count=sku_count,
+        created_at=profile.created_at,
+    )
+
+
+async def _get_profile(session: AsyncSession, profile_id: int) -> RepricingProfile:
+    profile = await session.get(RepricingProfile, profile_id)
+    if profile is None:
+        raise HTTPException(status_code=404, detail="Profile not found")
+    return profile
+
+
+async def _profile_detail(session: AsyncSession, profile: RepricingProfile) -> RepricingProfileDetail:
+    sku_rows = (
+        await session.execute(
+            select(Sku, Marketplace.code)
+            .join(Marketplace, Sku.marketplace_id == Marketplace.id)
+            .where(Sku.profile_id == profile.id)
+            .order_by(Sku.sku)
+        )
+    ).all()
+    sku_count = len(sku_rows)
+    return RepricingProfileDetail(
+        **_to_schema(profile, sku_count).model_dump(),
+        skus=[
+            ProfileSkuSummary(
+                id=sku.id,
+                sku=sku.sku,
+                asin=sku.asin,
+                marketplace_code=code,
+            )
+            for sku, code in sku_rows
+        ],
+    )
+
+
+@router.get("/", response_model=list[RepricingProfileOut])
+async def list_profiles(session: AsyncSession = Depends(get_db)) -> list[RepricingProfileOut]:
+    rows = (
+        await session.execute(
+            select(RepricingProfile, func.count(Sku.id))
+            .outerjoin(Sku)
+            .group_by(RepricingProfile.id)
+            .order_by(RepricingProfile.name)
+        )
+    ).all()
+    return [_to_schema(profile, int(count)) for profile, count in rows]
+
+
+@router.post("/", response_model=RepricingProfileOut, status_code=201)
+async def create_profile(
+    payload: RepricingProfileCreate,
+    session: AsyncSession = Depends(get_db),
+) -> RepricingProfileOut:
+    existing = await session.scalar(
+        select(RepricingProfile).where(RepricingProfile.name == payload.name)
+    )
+    if existing:
+        raise HTTPException(status_code=400, detail="Profile name already exists")
+    profile = RepricingProfile(
+        name=payload.name,
+        frequency_minutes=payload.frequency_minutes,
+        aggressiveness=payload.aggressiveness.model_dump(),
+        price_change_limit_percent=Decimal(str(payload.price_change_limit_percent)),
+        margin_policy=payload.margin_policy.model_dump(),
+        step_up_percentage=Decimal(str(payload.step_up_percentage)),
+        step_up_interval_hours=payload.step_up_interval_hours,
+    )
+    session.add(profile)
+    await session.commit()
+    await session.refresh(profile)
+    return _to_schema(profile, 0)
+
+
+@router.get("/{profile_id}", response_model=RepricingProfileDetail)
+async def get_profile(
+    profile_id: int,
+    session: AsyncSession = Depends(get_db),
+) -> RepricingProfileDetail:
+    profile = await _get_profile(session, profile_id)
+    return await _profile_detail(session, profile)
+
+
+@router.put("/{profile_id}", response_model=RepricingProfileOut)
+async def update_profile(
+    profile_id: int,
+    payload: RepricingProfileUpdate,
+    session: AsyncSession = Depends(get_db),
+) -> RepricingProfileOut:
+    profile = await _get_profile(session, profile_id)
+    if payload.name and payload.name != profile.name:
+        duplicate = await session.scalar(
+            select(RepricingProfile).where(
+                RepricingProfile.name == payload.name, RepricingProfile.id != profile.id
+            )
+        )
+        if duplicate:
+            raise HTTPException(status_code=400, detail="Profile name already exists")
+        profile.name = payload.name
+    if payload.frequency_minutes is not None:
+        profile.frequency_minutes = payload.frequency_minutes
+    if payload.aggressiveness is not None:
+        profile.aggressiveness = payload.aggressiveness.model_dump()
+    if payload.price_change_limit_percent is not None:
+        profile.price_change_limit_percent = Decimal(str(payload.price_change_limit_percent))
+    if payload.margin_policy is not None:
+        profile.margin_policy = payload.margin_policy.model_dump()
+    if payload.step_up_percentage is not None:
+        profile.step_up_percentage = Decimal(str(payload.step_up_percentage))
+    if payload.step_up_interval_hours is not None:
+        profile.step_up_interval_hours = payload.step_up_interval_hours
+    await session.commit()
+    await session.refresh(profile)
+    sku_count = await session.scalar(select(func.count()).where(Sku.profile_id == profile.id))
+    return _to_schema(profile, int(sku_count or 0))
+
+
+@router.delete("/{profile_id}")
+async def delete_profile(
+    profile_id: int,
+    session: AsyncSession = Depends(get_db),
+) -> dict[str, str]:
+    profile = await _get_profile(session, profile_id)
+    if profile.name == DEFAULT_PROFILE_NAME:
+        raise HTTPException(status_code=400, detail="Default profile cannot be deleted")
+    sku_count = await session.scalar(select(func.count()).where(Sku.profile_id == profile.id))
+    if sku_count:
+        raise HTTPException(status_code=400, detail="Profile has assigned SKUs")
+    await session.delete(profile)
+    await session.commit()
+    return {"status": "deleted"}
+
+
+@router.post("/{profile_id}/assign", response_model=RepricingProfileDetail)
+async def assign_skus(
+    profile_id: int,
+    payload: ProfileAssignmentRequest,
+    session: AsyncSession = Depends(get_db),
+) -> RepricingProfileDetail:
+    profile = await _get_profile(session, profile_id)
+    if not payload.assignments:
+        raise HTTPException(status_code=400, detail="No assignments provided")
+    pairs = {(item.sku, item.marketplace_code) for item in payload.assignments}
+    rows = (
+        await session.execute(
+            select(Sku.id, Sku.sku, Marketplace.code)
+            .join(Marketplace)
+            .where(tuple_(Sku.sku, Marketplace.code).in_(pairs))
+        )
+    ).all()
+    found = {(sku, code): sku_id for sku_id, sku, code in rows}
+    missing = [f"{sku}:{code}" for sku, code in pairs if (sku, code) not in found]
+    if missing:
+        raise HTTPException(
+            status_code=404,
+            detail=f"SKUs not found: {', '.join(sorted(missing))}",
+        )
+    await session.execute(
+        update(Sku).where(Sku.id.in_(found.values())).values(profile_id=profile.id)
+    )
+    await session.commit()
+    await session.refresh(profile)
+    return await _profile_detail(session, profile)

--- a/sdtrepricer/app/main.py
+++ b/sdtrepricer/app/main.py
@@ -14,6 +14,7 @@ from .api import api_router
 from .core.config import settings
 from .core.database import get_session, init_db
 from .core.logging import configure_logging
+from .migrations import run_migrations
 from .models import Marketplace
 from .services.scheduler import RepricingScheduler
 
@@ -50,6 +51,7 @@ async def ensure_marketplaces() -> None:
 @app.on_event("startup")
 async def on_startup() -> None:
     await init_db()
+    await run_migrations()
     await ensure_marketplaces()
     scheduler = RepricingScheduler()
     app.state.scheduler = scheduler

--- a/sdtrepricer/app/migrations/__init__.py
+++ b/sdtrepricer/app/migrations/__init__.py
@@ -1,0 +1,16 @@
+"""Simple data migrations executed at startup."""
+
+from __future__ import annotations
+
+from ..core.database import get_session
+from .profile_defaults import ensure_default_profile_assignment
+
+
+async def run_migrations() -> None:
+    """Run idempotent migrations to keep data in sync with models."""
+
+    async with get_session() as session:
+        await ensure_default_profile_assignment(session)
+
+
+__all__ = ["run_migrations"]

--- a/sdtrepricer/app/migrations/profile_defaults.py
+++ b/sdtrepricer/app/migrations/profile_defaults.py
@@ -1,0 +1,48 @@
+"""Utilities to create the default repricing profile."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..models import RepricingProfile, Sku
+
+DEFAULT_PROFILE_NAME = "Default"
+
+
+def _profile_defaults() -> dict[str, object]:
+    return {
+        "undercut_percent": 0.5,
+    }
+
+
+def _margin_defaults() -> dict[str, object]:
+    return {
+        "min_margin_percent": 0.0,
+    }
+
+
+async def ensure_default_profile_assignment(session: AsyncSession) -> None:
+    """Create a default profile and backfill SKUs lacking assignment."""
+
+    profile = await session.scalar(
+        select(RepricingProfile).where(RepricingProfile.name == DEFAULT_PROFILE_NAME)
+    )
+    if profile is None:
+        profile = RepricingProfile(
+            name=DEFAULT_PROFILE_NAME,
+            frequency_minutes=60,
+            aggressiveness=_profile_defaults(),
+            price_change_limit_percent=Decimal("20.00"),
+            margin_policy=_margin_defaults(),
+            step_up_percentage=Decimal("2.00"),
+            step_up_interval_hours=6,
+        )
+        session.add(profile)
+        await session.flush()
+    await session.execute(
+        update(Sku).where(Sku.profile_id.is_(None)).values(profile_id=profile.id)
+    )
+    await session.commit()

--- a/sdtrepricer/app/services/alerts.py
+++ b/sdtrepricer/app/services/alerts.py
@@ -20,7 +20,7 @@ async def create_alert(
     alert = Alert(
         message=message,
         severity=severity.value,
-        metadata=metadata,
+        metadata_payload=metadata,
         created_at=datetime.utcnow(),
     )
     session.add(alert)

--- a/sdtrepricer/app/static/css/dashboard.css
+++ b/sdtrepricer/app/static/css/dashboard.css
@@ -91,6 +91,30 @@ form input {
   border-radius: 8px;
 }
 
+form textarea {
+  margin-top: 0.25rem;
+  padding: 0.5rem;
+  border: 1px solid #cbd5f5;
+  border-radius: 8px;
+  resize: vertical;
+}
+
+.profile-management {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.profile-details p {
+  margin: 0.2rem 0;
+}
+
+#profile-sku-list {
+  max-height: 200px;
+  overflow-y: auto;
+  padding-left: 1rem;
+}
+
 button {
   padding: 0.6rem 1rem;
   border: none;

--- a/sdtrepricer/app/static/js/dashboard.js
+++ b/sdtrepricer/app/static/js/dashboard.js
@@ -1,4 +1,6 @@
 const API_BASE = '/api';
+let profileCache = [];
+let selectedProfileId = null;
 
 async function fetchJSON(url, options = {}) {
   const response = await fetch(url, {
@@ -59,6 +61,197 @@ function populateSettings(settings) {
   form.step_up_interval_hours.value = settings.step_up_interval_hours;
 }
 
+function setProfileStatus(message) {
+  const status = document.getElementById('profile-status');
+  if (status) {
+    status.textContent = message;
+  }
+}
+
+function populateManualProfileOptions(profiles) {
+  const manualSelect = document.getElementById('manual-profile-select');
+  if (!manualSelect) {
+    return;
+  }
+  const previous = manualSelect.value;
+  manualSelect.innerHTML = '<option value="">All profiles</option>';
+  profiles.forEach((profile) => {
+    const option = document.createElement('option');
+    option.value = profile.id;
+    option.textContent = profile.name;
+    manualSelect.appendChild(option);
+  });
+  if (profiles.some((profile) => String(profile.id) === previous)) {
+    manualSelect.value = previous;
+  }
+}
+
+function renderProfileDetail(detail) {
+  const container = document.getElementById('profile-details');
+  const list = document.getElementById('profile-sku-list');
+  if (!container || !list) {
+    return;
+  }
+  if (!detail) {
+    container.innerHTML = '<p>Select a profile to view configuration.</p>';
+    list.innerHTML = '';
+    selectedProfileId = null;
+    return;
+  }
+  const undercut = detail.aggressiveness?.undercut_percent ?? 0;
+  const margin = detail.margin_policy?.min_margin_percent ?? 0;
+  container.innerHTML = `
+    <p><strong>Name:</strong> ${detail.name}</p>
+    <p><strong>Frequency:</strong> every ${detail.frequency_minutes} minutes</p>
+    <p><strong>Undercut:</strong> ${Number(undercut).toFixed(2)}%</p>
+    <p><strong>Daily change limit:</strong> ${Number(detail.price_change_limit_percent).toFixed(2)}%</p>
+    <p><strong>Minimum margin:</strong> ${Number(margin).toFixed(2)}%</p>
+    <p><strong>Step-up:</strong> ${Number(detail.step_up_percentage).toFixed(2)}% every ${detail.step_up_interval_hours} hours</p>
+    <p><strong>Assigned SKUs:</strong> ${detail.sku_count}</p>
+  `;
+  list.innerHTML = '';
+  if (!detail.skus || detail.skus.length === 0) {
+    const li = document.createElement('li');
+    li.textContent = 'No SKUs assigned';
+    list.appendChild(li);
+  } else {
+    detail.skus.forEach((sku) => {
+      const li = document.createElement('li');
+      li.textContent = `${sku.marketplace_code} :: ${sku.sku} (${sku.asin})`;
+      list.appendChild(li);
+    });
+  }
+  selectedProfileId = detail.id;
+  const selector = document.getElementById('profile-selector');
+  if (selector) {
+    selector.value = String(detail.id);
+  }
+}
+
+function renderProfiles(profiles) {
+  profileCache = profiles;
+  const selector = document.getElementById('profile-selector');
+  if (!selector) {
+    return;
+  }
+  const previous = selectedProfileId ? String(selectedProfileId) : selector.value;
+  selector.innerHTML = '<option value="">-- None --</option>';
+  profiles.forEach((profile) => {
+    const option = document.createElement('option');
+    option.value = profile.id;
+    option.textContent = `${profile.name} (${profile.sku_count})`;
+    selector.appendChild(option);
+  });
+  if (profiles.some((profile) => String(profile.id) === previous)) {
+    selector.value = previous;
+    selectedProfileId = Number(previous);
+  } else if (profiles.length > 0) {
+    selector.value = String(profiles[0].id);
+    selectedProfileId = profiles[0].id;
+  } else {
+    selector.value = '';
+    selectedProfileId = null;
+  }
+  populateManualProfileOptions(profiles);
+  if (!selectedProfileId) {
+    renderProfileDetail(null);
+  }
+}
+
+async function loadProfileDetail(profileId) {
+  if (!profileId) {
+    renderProfileDetail(null);
+    return;
+  }
+  try {
+    const detail = await fetchJSON(`${API_BASE}/profiles/${profileId}`);
+    renderProfileDetail(detail);
+  } catch (error) {
+    console.error('Failed to load profile detail', error);
+    setProfileStatus(`Failed to load profile: ${error.message}`);
+    renderProfileDetail(null);
+  }
+}
+
+async function loadProfiles() {
+  try {
+    const data = await fetchJSON(`${API_BASE}/profiles`);
+    renderProfiles(data);
+    if (selectedProfileId) {
+      await loadProfileDetail(selectedProfileId);
+    }
+  } catch (error) {
+    console.error('Failed to load profiles', error);
+    setProfileStatus(`Failed to load profiles: ${error.message}`);
+  }
+}
+
+async function handleProfileCreate(event) {
+  event.preventDefault();
+  const form = event.target;
+  const payload = {
+    name: form.name.value,
+    frequency_minutes: parseInt(form.frequency_minutes.value, 10),
+    aggressiveness: {
+      undercut_percent: parseFloat(form.undercut_percent.value),
+    },
+    price_change_limit_percent: parseFloat(form.price_change_limit_percent.value),
+    margin_policy: {
+      min_margin_percent: parseFloat(form.min_margin_percent.value),
+    },
+    step_up_percentage: parseFloat(form.step_up_percentage.value),
+    step_up_interval_hours: parseInt(form.step_up_interval_hours.value, 10),
+  };
+  try {
+    const created = await fetchJSON(`${API_BASE}/profiles`, {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    });
+    selectedProfileId = created.id;
+    form.reset();
+    setProfileStatus(`Created profile ${created.name}`);
+    await loadProfiles();
+  } catch (error) {
+    setProfileStatus(`Failed to create profile: ${error.message}`);
+  }
+}
+
+async function handleProfileAssign(event) {
+  event.preventDefault();
+  const form = event.target;
+  if (!selectedProfileId) {
+    setProfileStatus('Select a profile before assigning SKUs');
+    return;
+  }
+  const marketplaceCode = form.marketplace_code.value.trim().toUpperCase();
+  const skuEntries = form.skus.value
+    .split(',')
+    .map((sku) => sku.trim())
+    .filter((sku) => sku.length > 0);
+  if (skuEntries.length === 0) {
+    setProfileStatus('Provide at least one SKU to assign');
+    return;
+  }
+  const payload = {
+    assignments: skuEntries.map((sku) => ({
+      sku,
+      marketplace_code: marketplaceCode,
+    })),
+  };
+  try {
+    const detail = await fetchJSON(`${API_BASE}/profiles/${selectedProfileId}/assign`, {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    });
+    setProfileStatus(`Assigned ${skuEntries.length} SKU(s) to ${detail.name}`);
+    form.reset();
+    await loadProfiles();
+    renderProfileDetail(detail);
+  } catch (error) {
+    setProfileStatus(`Failed to assign SKUs: ${error.message}`);
+  }
+}
+
 async function refreshDashboard() {
   try {
     const data = await fetchJSON(`${API_BASE}/metrics/dashboard`);
@@ -93,9 +286,11 @@ async function handleSettings(event) {
 async function handleManualReprice(event) {
   event.preventDefault();
   const form = event.target;
+  const profileValue = form.profile_id.value;
   const payload = {
     marketplace_code: form.marketplace_code.value.toUpperCase(),
     skus: [],
+    profile_id: profileValue ? parseInt(profileValue, 10) : null,
   };
   try {
     await fetchJSON(`${API_BASE}/actions/manual-reprice`, {
@@ -150,6 +345,18 @@ document.getElementById('settings-form').addEventListener('submit', handleSettin
 document.getElementById('manual-reprice-form').addEventListener('submit', handleManualReprice);
 document.getElementById('manual-price-form').addEventListener('submit', handleManualPrice);
 document.getElementById('bulk-upload-form').addEventListener('submit', handleBulkUpload);
+document.getElementById('profile-create-form').addEventListener('submit', handleProfileCreate);
+document.getElementById('profile-assign-form').addEventListener('submit', handleProfileAssign);
+document.getElementById('profile-selector').addEventListener('change', (event) => {
+  const value = event.target.value;
+  selectedProfileId = value ? Number(value) : null;
+  if (selectedProfileId) {
+    loadProfileDetail(selectedProfileId);
+  } else {
+    renderProfileDetail(null);
+  }
+});
 
 refreshDashboard();
 setInterval(refreshDashboard, 15000);
+loadProfiles();

--- a/sdtrepricer/app/templates/dashboard.html
+++ b/sdtrepricer/app/templates/dashboard.html
@@ -51,12 +51,79 @@
           <button type="submit">Update Settings</button>
         </form>
       </section>
+      <section class="profiles">
+        <h2>Repricing Profiles</h2>
+        <div class="profile-management">
+          <div class="profile-list">
+            <label>
+              Select profile
+              <select id="profile-selector">
+                <option value="">-- None --</option>
+              </select>
+            </label>
+            <div id="profile-details" class="profile-details"></div>
+            <h3>Assigned SKUs</h3>
+            <ul id="profile-sku-list"></ul>
+          </div>
+          <form id="profile-create-form">
+            <h3>Create profile</h3>
+            <label>
+              Name
+              <input name="name" required />
+            </label>
+            <label>
+              Frequency (minutes)
+              <input type="number" name="frequency_minutes" min="5" required />
+            </label>
+            <label>
+              Undercut percent
+              <input type="number" step="0.1" name="undercut_percent" min="0" max="100" required />
+            </label>
+            <label>
+              Price change limit (%)
+              <input type="number" step="0.1" name="price_change_limit_percent" min="0.1" required />
+            </label>
+            <label>
+              Minimum margin (%)
+              <input type="number" step="0.1" name="min_margin_percent" min="0" required />
+            </label>
+            <label>
+              Step-up percentage
+              <input type="number" step="0.1" name="step_up_percentage" min="0" required />
+            </label>
+            <label>
+              Step-up interval (hours)
+              <input type="number" name="step_up_interval_hours" min="1" required />
+            </label>
+            <button type="submit">Create Profile</button>
+          </form>
+        </div>
+        <form id="profile-assign-form">
+          <h3>Assign SKUs to selected profile</h3>
+          <label>
+            Marketplace code
+            <input name="marketplace_code" maxlength="2" required />
+          </label>
+          <label>
+            SKU list (comma separated)
+            <textarea name="skus" rows="3" required></textarea>
+          </label>
+          <button type="submit">Assign SKUs</button>
+        </form>
+        <div id="profile-status"></div>
+      </section>
       <section class="actions">
         <h2>Manual Controls</h2>
         <form id="manual-reprice-form">
           <label>
             Marketplace code
             <input name="marketplace_code" maxlength="2" required />
+          </label>
+          <label>
+            Profile (optional)
+            <select name="profile_id" id="manual-profile-select">
+              <option value="">All profiles</option>
+            </select>
           </label>
           <button type="submit">Trigger Repricing</button>
         </form>

--- a/sdtrepricer/tests/conftest.py
+++ b/sdtrepricer/tests/conftest.py
@@ -1,22 +1,71 @@
 from __future__ import annotations
 
 from collections.abc import AsyncIterator
+from pathlib import Path
+import sys
 
 import pytest
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+ROOT_DIR = Path(__file__).resolve().parents[2]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
 
 from sdtrepricer.app.models import Base
 
 
+class AsyncSessionWrapper:
+    """Minimal async wrapper around a synchronous SQLAlchemy session."""
+
+    def __init__(self, sync_session: Session) -> None:
+        self._session = sync_session
+
+    def add(self, obj) -> None:
+        self._session.add(obj)
+
+    def add_all(self, objects) -> None:
+        self._session.add_all(objects)
+
+    async def execute(self, *args, **kwargs):
+        return self._session.execute(*args, **kwargs)
+
+    async def scalar(self, *args, **kwargs):
+        return self._session.scalar(*args, **kwargs)
+
+    async def scalars(self, *args, **kwargs):
+        return self._session.scalars(*args, **kwargs)
+
+    async def get(self, *args, **kwargs):
+        return self._session.get(*args, **kwargs)
+
+    async def commit(self) -> None:
+        self._session.commit()
+
+    async def flush(self) -> None:
+        self._session.flush()
+
+    async def rollback(self) -> None:
+        self._session.rollback()
+
+    async def refresh(self, instance) -> None:
+        self._session.refresh(instance)
+
+    async def close(self) -> None:
+        self._session.close()
+
+
 @pytest.fixture
-async def db_session() -> AsyncIterator[AsyncSession]:
-    engine = create_async_engine("sqlite+aiosqlite:///:memory:", echo=False)
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-    session_factory = async_sessionmaker(engine, expire_on_commit=False)
-    async with session_factory() as session:  # type: ignore[call-arg]
-        yield session
-    await engine.dispose()
+async def db_session() -> AsyncIterator[AsyncSessionWrapper]:
+    engine = create_engine("sqlite:///:memory:", future=True)
+    Base.metadata.create_all(engine)
+    SessionLocal = sessionmaker(bind=engine)
+    session = SessionLocal()
+    try:
+        yield AsyncSessionWrapper(session)
+    finally:
+        session.close()
+        engine.dispose()
 
 
 @pytest.fixture

--- a/sdtrepricer/tests/test_dashboard_api.py
+++ b/sdtrepricer/tests/test_dashboard_api.py
@@ -5,7 +5,7 @@ from decimal import Decimal
 
 import pytest
 from fastapi import FastAPI
-from httpx import AsyncClient
+from httpx import ASGITransport, AsyncClient
 
 from sdtrepricer.app.api import api_router
 from sdtrepricer.app.dependencies import get_db
@@ -38,8 +38,8 @@ async def test_dashboard_endpoint(db_session):
 
     class StubScheduler:
         def __init__(self) -> None:
-            self.last_runs = {"DE": datetime.utcnow() - timedelta(minutes=5)}
-            self.stats = {"DE": {"updated": 1, "processed": 10}}
+            self.last_runs = {"DE:all": datetime.utcnow() - timedelta(minutes=5)}
+            self.stats = {"DE:all": {"updated": 1, "processed": 10}}
 
     app.state.scheduler = StubScheduler()
 
@@ -48,7 +48,7 @@ async def test_dashboard_endpoint(db_session):
 
     app.dependency_overrides[get_db] = override_get_db
 
-    async with AsyncClient(app=app, base_url="http://test") as client:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         response = await client.get("/api/metrics/dashboard")
     assert response.status_code == 200
     payload = response.json()

--- a/sdtrepricer/tests/test_profiles_api.py
+++ b/sdtrepricer/tests/test_profiles_api.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from sdtrepricer.app.api import api_router
+from sdtrepricer.app.dependencies import get_db
+from sdtrepricer.app.models import Marketplace, Sku
+
+
+@pytest.mark.anyio
+async def test_profile_crud_and_assignment(db_session):
+    marketplace = Marketplace(code="DE", name="Germany", amazon_id="A1")
+    sku = Sku(
+        sku="SKU-PROFILE",
+        asin="ASIN-PROFILE",
+        marketplace=marketplace,
+        profile=None,
+        min_price=Decimal("9.99"),
+        min_business_price=None,
+    )
+    db_session.add_all([marketplace, sku])
+    await db_session.commit()
+
+    app = FastAPI()
+    app.include_router(api_router, prefix="/api")
+
+    async def override_get_db():
+        yield db_session
+
+    app.dependency_overrides[get_db] = override_get_db
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        create_payload = {
+            "name": "Evening",
+            "frequency_minutes": 45,
+            "aggressiveness": {"undercut_percent": 1.5},
+            "price_change_limit_percent": 25.0,
+            "margin_policy": {"min_margin_percent": 2.0},
+            "step_up_percentage": 3.0,
+            "step_up_interval_hours": 4,
+        }
+        response = await client.post("/api/profiles/", json=create_payload)
+        assert response.status_code == 201
+        profile = response.json()
+        profile_id = profile["id"]
+
+        assign_payload = {
+            "assignments": [
+                {"sku": "SKU-PROFILE", "marketplace_code": "DE"},
+            ]
+        }
+        response = await client.post(f"/api/profiles/{profile_id}/assign", json=assign_payload)
+        assert response.status_code == 200
+        detail = response.json()
+        assert detail["sku_count"] == 1
+        assert detail["skus"][0]["sku"] == "SKU-PROFILE"
+
+        response = await client.get(f"/api/profiles/{profile_id}")
+        assert response.status_code == 200
+        assert response.json()["sku_count"] == 1
+
+        response = await client.put(
+            f"/api/profiles/{profile_id}",
+            json={"frequency_minutes": 30, "name": "Evening Update"},
+        )
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["frequency_minutes"] == 30
+        assert payload["name"] == "Evening Update"
+
+        response = await client.get("/api/profiles/")
+        assert response.status_code == 200
+        profiles = response.json()
+        assert any(item["sku_count"] == 1 for item in profiles if item["id"] == profile_id)

--- a/sdtrepricer/tests/test_repricer.py
+++ b/sdtrepricer/tests/test_repricer.py
@@ -5,7 +5,7 @@ from decimal import Decimal
 import pytest
 from sqlalchemy import select
 
-from sdtrepricer.app.models import Marketplace, PriceEvent, Sku
+from sdtrepricer.app.models import Marketplace, PriceEvent, RepricingProfile, Sku
 from sdtrepricer.app.services.ftp_loader import FloorPriceRecord
 from sdtrepricer.app.services.repricer import PricingStrategy, Repricer
 
@@ -24,8 +24,9 @@ class StubFTP:
 
 
 class StubSPAPI:
-    def __init__(self) -> None:
+    def __init__(self, competitor_price: float = 18.0) -> None:
         self.updates: list[tuple[str, float, float | None]] = []
+        self.competitor_price = competitor_price
 
     async def get_competitive_pricing(self, marketplace_id: str, asins: list[str]):
         return {
@@ -41,7 +42,7 @@ class StubSPAPI:
                         {
                             "sellerId": "B",
                             "isBuyBoxWinner": False,
-                            "listingPrice": {"amount": 18.0},
+                            "listingPrice": {"amount": self.competitor_price},
                         },
                     ],
                 }
@@ -61,16 +62,25 @@ class StubSPAPI:
 @pytest.mark.anyio
 async def test_repricer_updates_prices(db_session):
     marketplace = Marketplace(code="DE", name="Germany", amazon_id="A1")
+    profile = RepricingProfile(
+        name="Default",
+        frequency_minutes=60,
+        aggressiveness={"undercut_percent": 0.5},
+        price_change_limit_percent=Decimal("20.0"),
+        margin_policy={"min_margin_percent": 0.0},
+        step_up_percentage=Decimal("2.0"),
+        step_up_interval_hours=6,
+    )
     sku = Sku(
         sku="SKU1",
         asin="ASIN1",
         marketplace=marketplace,
+        profile=profile,
         min_price=Decimal("10.00"),
         min_business_price=Decimal("12.00"),
         last_updated_price=Decimal("15.00"),
     )
-    db_session.add(marketplace)
-    db_session.add(sku)
+    db_session.add_all([marketplace, profile, sku])
     await db_session.commit()
 
     ftp = StubFTP(FloorPriceRecord("SKU1", "ASIN1", 10.0, 12.0))
@@ -87,3 +97,39 @@ async def test_repricer_updates_prices(db_session):
     assert len(events) == 1
     assert events[0].reason == "repricer"
     assert sp.updates[0][0] == "SKU1"
+
+
+@pytest.mark.anyio
+async def test_profile_aggressiveness_applied(db_session):
+    marketplace = Marketplace(code="DE", name="Germany", amazon_id="A1")
+    profile = RepricingProfile(
+        name="Aggressive",
+        frequency_minutes=15,
+        aggressiveness={"undercut_percent": 5.0},
+        price_change_limit_percent=Decimal("50.0"),
+        margin_policy={"min_margin_percent": 0.0},
+        step_up_percentage=Decimal("1.0"),
+        step_up_interval_hours=6,
+    )
+    sku = Sku(
+        sku="SKU2",
+        asin="ASIN2",
+        marketplace=marketplace,
+        profile=profile,
+        min_price=Decimal("10.00"),
+        min_business_price=None,
+        last_updated_price=Decimal("25.00"),
+    )
+    db_session.add_all([marketplace, profile, sku])
+    await db_session.commit()
+
+    ftp = StubFTP(FloorPriceRecord("SKU2", "ASIN2", 10.0, None))
+    sp = StubSPAPI(competitor_price=20.0)
+    repricer = Repricer(db_session, sp, ftp, PricingStrategy())
+
+    result = await repricer.run_marketplace("DE", profile_id=profile.id)
+
+    await db_session.refresh(sku)
+    assert pytest.approx(float(sku.last_updated_price), rel=1e-3) == 19.0
+    assert result["profile_id"] == profile.id
+    assert profile.id in result.get("profiles_processed", [])

--- a/sdtrepricer/tests/test_scheduler.py
+++ b/sdtrepricer/tests/test_scheduler.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from datetime import datetime, timedelta
+from decimal import Decimal
+
+import pytest
+
+from sdtrepricer.app.models import Marketplace, RepricingProfile, Sku
+from sdtrepricer.app.services.scheduler import RepricingScheduler
+
+
+@pytest.mark.anyio
+async def test_scheduler_uses_profile_frequency(db_session, monkeypatch):
+    marketplace = Marketplace(code="DE", name="Germany", amazon_id="A1")
+    fast_profile = RepricingProfile(
+        name="Fast",
+        frequency_minutes=15,
+        aggressiveness={"undercut_percent": 1.0},
+        price_change_limit_percent=Decimal("40.0"),
+        margin_policy={"min_margin_percent": 0.0},
+        step_up_percentage=Decimal("2.0"),
+        step_up_interval_hours=6,
+    )
+    slow_profile = RepricingProfile(
+        name="Slow",
+        frequency_minutes=120,
+        aggressiveness={"undercut_percent": 0.5},
+        price_change_limit_percent=Decimal("40.0"),
+        margin_policy={"min_margin_percent": 0.0},
+        step_up_percentage=Decimal("2.0"),
+        step_up_interval_hours=6,
+    )
+    sku_fast = Sku(
+        sku="FAST-SKU",
+        asin="FAST",
+        marketplace=marketplace,
+        profile=fast_profile,
+        min_price=Decimal("10.00"),
+        min_business_price=None,
+    )
+    sku_slow = Sku(
+        sku="SLOW-SKU",
+        asin="SLOW",
+        marketplace=marketplace,
+        profile=slow_profile,
+        min_price=Decimal("10.00"),
+        min_business_price=None,
+    )
+    db_session.add_all([marketplace, fast_profile, slow_profile, sku_fast, sku_slow])
+    await db_session.commit()
+
+    scheduler = RepricingScheduler()
+    calls: list[tuple[str, int | None]] = []
+
+    async def fake_trigger(marketplace_code: str, reason: str = "manual", profile_id: int | None = None):
+        calls.append((marketplace_code, profile_id))
+
+    scheduler.trigger_marketplace = fake_trigger  # type: ignore[assignment]
+
+    @asynccontextmanager
+    async def fake_session():
+        yield db_session
+
+    monkeypatch.setattr("sdtrepricer.app.services.scheduler.get_session", fake_session)
+
+    await scheduler._run_scheduled_cycle()
+    assert (marketplace.code, fast_profile.id) in calls
+    assert (marketplace.code, slow_profile.id) in calls
+
+    calls.clear()
+    scheduler.last_runs[scheduler._key(marketplace.code, fast_profile.id)] = datetime.utcnow()
+    scheduler.last_runs[scheduler._key(marketplace.code, slow_profile.id)] = datetime.utcnow() - timedelta(
+        minutes=slow_profile.frequency_minutes + 1
+    )
+
+    await scheduler._run_scheduled_cycle()
+    assert calls == [(marketplace.code, slow_profile.id)]

--- a/sdtrepricer/tests/test_strategy.py
+++ b/sdtrepricer/tests/test_strategy.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from datetime import datetime, timedelta
 from decimal import Decimal
 
+import pytest
+
 from sdtrepricer.app.models import Sku
 from sdtrepricer.app.services.ftp_loader import FloorPriceRecord
 from sdtrepricer.app.services.repricer import CompetitorOffer, PricingStrategy
@@ -51,4 +53,4 @@ def test_daily_threshold_is_enforced():
     offers = [CompetitorOffer("sellerA", 40.0, False, "FBA")]
     strategy = PricingStrategy(max_daily_change_percent=10)
     result = strategy.determine_price(sku, offers, floor)
-    assert result.new_price <= Decimal("22.00")
+    assert float(result.new_price) <= 22.0001


### PR DESCRIPTION
## Summary
- add a RepricingProfile ORM model, migration helper, and default backfill for existing SKUs
- expose CRUD endpoints and tests for profile management plus SKU assignment
- apply per-profile scheduling/strategy in the scheduler and repricer and surface controls in the dashboard UI

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c965f0474c8325a88007ecfcbe16e8